### PR TITLE
Prep RHDH RAG image for release-1.8

### DIFF
--- a/Containerfile.rhdh_lightspeed
+++ b/Containerfile.rhdh_lightspeed
@@ -1,6 +1,6 @@
 ARG FLAVOR=cpu
 FROM quay.io/lightspeed-core/rag-content-${FLAVOR}:latest as lightspeed-core-rag-builder
-ARG RHDH_DOCS_VERSION="1.7"
+ARG RHDH_DOCS_VERSION="1.8"
 ARG NUM_WORKERS=1
 
 USER 0
@@ -46,7 +46,7 @@ LABEL io.k8s.description="Red Hat Developer Hub Lightspeed RAG content"
 LABEL io.k8s.display-name="Red Hat Developer Hub Lightspeed RAG content"
 LABEL io.openshift.tags="developerhub,rhdh,lightspeed,ai,assistant,rag"
 LABEL name=rhdh-lightspeed-rag-content
-LABEL release=0.0.1
+LABEL release=1.8
 LABEL url="https://github.com/redhat-ai-dev/rhdh-rag-content"
 LABEL vendor="Red Hat, Inc."
 LABEL version=0.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rhdh-rag-content"
 description = "RAG for RHDH"
 version = "0.1.0"
 dependencies = [
-    "lightspeed-rag-content @ git+https://github.com/lightspeed-core/rag-content@main",
+    "lightspeed-rag-content @ git+https://github.com/lightspeed-core/rag-content@0d4c9c81ab02c0aa7e478829739c0c0a59c9d1b6",
     "pyyaml",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -636,7 +636,7 @@ wheels = [
 [[package]]
 name = "lightspeed-rag-content"
 version = "0.1.0"
-source = { git = "https://github.com/lightspeed-core/rag-content?rev=main#218898f06aea3a2f4afde0ab36cd58f6b66a623c" }
+source = { git = "https://github.com/lightspeed-core/rag-content?rev=0d4c9c81ab02c0aa7e478829739c0c0a59c9d1b6#0d4c9c81ab02c0aa7e478829739c0c0a59c9d1b6" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "faiss-cpu" },
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "lightspeed-rag-content", git = "https://github.com/lightspeed-core/rag-content?rev=main" },
+    { name = "lightspeed-rag-content", git = "https://github.com/lightspeed-core/rag-content?rev=0d4c9c81ab02c0aa7e478829739c0c0a59c9d1b6" },
     { name = "pyyaml" },
 ]
 


### PR DESCRIPTION
- Prep RHDH RAG image for release-1.8
- Built image for release-1.8 has been manually pushed to https://quay.io/repository/redhat-ai-dev/rag-content?tab=tags
- Tagged rag-content repo to a commit instead of main branch
- DO NOT MERGE until we do a quick sniff test once RHDH Docs 1.8 have published at https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.7
- We can also run the workflow from this repo to build images for arm and amd arch
- We can start promoting the image after confirming RHDH Docs 1.8 has been published