### PR TITLE
[RHIDP-10080] Bump Upstream Version of Rag Content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "rhdh-rag-content"
 description = "RAG for RHDH"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
-    "lightspeed-rag-content @ git+https://github.com/lightspeed-core/rag-content@0d4c9c81ab02c0aa7e478829739c0c0a59c9d1b6",
+    "lightspeed-rag-content @ git+https://github.com/lightspeed-core/rag-content@d90df77e415eae8575621cec23fa919a5c99a197",
     "pyyaml",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -453,6 +453,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
     { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/27/45/80935968b53cfd3f33cf99ea5f08227f2646e044568c9b1555b58ffd61c2/greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0", size = 1564846, upload-time = "2025-11-04T12:42:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/b7c30e5e04752cb4db6202a3858b149c0710e5453b71a3b2aec5d78a1aab/greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d", size = 1633814, upload-time = "2025-11-04T12:42:17.175Z" },
     { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
 ]
 
@@ -636,7 +638,7 @@ wheels = [
 [[package]]
 name = "lightspeed-rag-content"
 version = "0.1.0"
-source = { git = "https://github.com/lightspeed-core/rag-content?rev=0d4c9c81ab02c0aa7e478829739c0c0a59c9d1b6#0d4c9c81ab02c0aa7e478829739c0c0a59c9d1b6" }
+source = { git = "https://github.com/lightspeed-core/rag-content?rev=d90df77e415eae8575621cec23fa919a5c99a197#d90df77e415eae8575621cec23fa919a5c99a197" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "faiss-cpu" },
@@ -653,23 +655,6 @@ dependencies = [
     { name = "tomlkit" },
     { name = "torch", version = "2.7.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.7.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
-]
-
-[[package]]
-name = "llama-api-client"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/62/43/33f7eccd2a6b85d391afd4f779f699b0015ccd7b6ffd14d10f14d60ae147/llama_api_client-0.3.0.tar.gz", hash = "sha256:4355379f5c870aaaacc1af6ae3f0115e74bd3ee560531c6d48b483d41a281a43", size = 117749, upload-time = "2025-08-27T00:59:22.179Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/d2/ddbeb8c8a6bfd13c38ae39a9bfd83b9dcc92259b5c9f6d2388b5d00aa65e/llama_api_client-0.3.0-py3-none-any.whl", hash = "sha256:0b823b4541b0522de31124bd09a7ba7358598aa3fb17e20ad08cbdc78f4a8408", size = 85162, upload-time = "2025-08-27T00:59:20.913Z" },
 ]
 
 [[package]]
@@ -986,7 +971,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack"
-version = "0.2.16"
+version = "0.2.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -999,7 +984,6 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "jinja2" },
     { name = "jsonschema" },
-    { name = "llama-api-client" },
     { name = "llama-stack-client" },
     { name = "openai" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -1016,14 +1000,14 @@ dependencies = [
     { name = "tiktoken" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3d73f4bfcf34ef7c703f3f3cfbe635f500b044c78fd33302199dce3ac698/llama_stack-0.2.16.tar.gz", hash = "sha256:e1ffb5400c85bf23b97f8f48028cb85061bb87a72b741faace1a174215f5de32", size = 3284603, upload-time = "2025-07-28T23:13:32.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/cf/c4bccdb6e218f3fda1d50aad87bf08376372c56ddc523e35f5a629c725e1/llama_stack-0.2.22.tar.gz", hash = "sha256:576752dedc9e9f0fb9da69f373d677d8b4f2ae4203428f676fa039b6813d8450", size = 3334595, upload-time = "2025-09-16T19:43:41.842Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/36/35cc221603aa7c23efb41a88dd7c122af96740f50191d1da0ab9dc74056d/llama_stack-0.2.16-py3-none-any.whl", hash = "sha256:b9313acb150360467d7cccb54adb160b2fd585b7ab2505e88b5320c6bf766efe", size = 3603056, upload-time = "2025-07-28T23:13:30.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/42/5ae8be5371367beb9c8e38966cd941022c072fb2133660bf0eabc7b5d08b/llama_stack-0.2.22-py3-none-any.whl", hash = "sha256:c6bbda6b5a4417b9a73ed36b9d581fd7ec689090ceefd084d9a078e7acbdc670", size = 3669928, upload-time = "2025-09-16T19:43:40.391Z" },
 ]
 
 [[package]]
 name = "llama-stack-client"
-version = "0.2.16"
+version = "0.2.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1042,9 +1026,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/28/74ae2faae9af51205587b33fcf2f99a8af090de7aa4122701f2f70f04233/llama_stack_client-0.2.16.tar.gz", hash = "sha256:24294acc6bf40e79900a62f4fa61009acb9af7028b198b12c0ba8adab25c2049", size = 257642, upload-time = "2025-07-28T23:13:22.793Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/80/4260816bfaaa889d515206c9df4906d08d405bf94c9b4d1be399b1923e46/llama_stack_client-0.2.22.tar.gz", hash = "sha256:9a0bc756b91ebd539858eeaf1f231c5e5c6900e1ea4fcced726c6717f3d27ca7", size = 318309, upload-time = "2025-09-16T19:43:33.212Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/ec/1874120a15b22f3a88d4e49700c870cc6540bc8c709a841db79a662d7949/llama_stack_client-0.2.16-py3-none-any.whl", hash = "sha256:5c0d13e6ac40143ce01cae4eec65fb39fe24e11f54b86afbd20f0033c38f83c0", size = 350329, upload-time = "2025-07-28T23:13:21.586Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/8e/1ebf6ac0dbb62b81038e856ed00768e283d927b14fcd614e3018a227092b/llama_stack_client-0.2.22-py3-none-any.whl", hash = "sha256:b260d73aec56fcfd8fa601b3b34c2f83c4fbcfb7261a246b02bbdf6c2da184fe", size = 369901, upload-time = "2025-09-16T19:43:32.089Z" },
 ]
 
 [[package]]
@@ -1653,7 +1637,7 @@ wheels = [
 
 [[package]]
 name = "rhdh-rag-content"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "lightspeed-rag-content" },
@@ -1662,7 +1646,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "lightspeed-rag-content", git = "https://github.com/lightspeed-core/rag-content?rev=0d4c9c81ab02c0aa7e478829739c0c0a59c9d1b6" },
+    { name = "lightspeed-rag-content", git = "https://github.com/lightspeed-core/rag-content?rev=d90df77e415eae8575621cec23fa919a5c99a197" },
     { name = "pyyaml" },
 ]
 


### PR DESCRIPTION
# Description
- Bumps the upstream to the latest PR merge
- Tested locally by building the image and using it alongside our Llama Stack + Lightspeed Core setup, was able to get a response properly querying the RAG content (see below)

# Issue

https://issues.redhat.com/browse/RHIDP-10080

<img width="1085" height="747" alt="Screenshot 2025-12-08 at 12 52 38 PM" src="https://github.com/user-attachments/assets/1186c01b-c7f9-44ba-8825-ad3265a1aff2" />
