### PR TITLE
Add github sha to base images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAME }}
           tags: |
-            ${{ env.LATEST_TAG }}-${{ matrix.arch }}
+            ${{ env.LATEST_TAG }}-${{ matrix.arch }}-${{ github.sha }}
           containerfiles: |
             ${{ env.CONTAINER_FILE }}
           archs: ${{ matrix.arch }}
@@ -128,12 +128,12 @@ jobs:
         run: |
           # Create manifests
           buildah manifest create ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
-          buildah manifest add ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }} ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-amd64
-          buildah manifest add ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }} ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-arm64
+          buildah manifest add ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }} ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-amd64-${{ github.sha }}
+          buildah manifest add ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }} ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-arm64-${{ github.sha }}
           
           buildah manifest create ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-${{ github.sha }}
-          buildah manifest add ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-${{ github.sha }} ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-amd64
-          buildah manifest add ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-${{ github.sha }} ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-arm64
+          buildah manifest add ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-${{ github.sha }} ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-amd64-${{ github.sha }}
+          buildah manifest add ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-${{ github.sha }} ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}-arm64-${{ github.sha }}
           
           # Push manifests
           buildah manifest push --all ${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }} docker://${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}


### PR DESCRIPTION
- Adds the github commit hash to the base images that the manifest references
- Avoids an issue where the references can get overwritten