### PR TITLE
Onboard renovate

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -98,10 +98,10 @@ jobs:
           sudo apt update
           sudo apt install -y buildah
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Build image with Buildah
         id: build_image
-        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 #v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
           layers: true
           image: ${{ env.IMAGE_NAME }}
@@ -121,7 +121,7 @@ jobs:
           echo '${{ steps.build_image.outputs.image }}'
           echo '${{ steps.build_image.outputs.tags }}'
       - name: Push architecture-specific image to Quay.io
-        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c #v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.build_image.outputs.tags }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "helpers:pinGitHubActionDigests",
+    ":gitSignOff"
+  ],
+  "timezone": "America/Toronto",
+  "schedule": [
+    "* 19-23 * * 0",
+    "* 0-2 * * 1"
+  ],
+  "enabledManagers": [
+    "dockerfile",
+    "github-actions",
+    "custom.regex",
+    "pep621"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "pyproject\\.toml$"
+      ],
+      "matchStrings": [
+        "\"(?<depName>\\S*)\\s+@\\s+git\\+(?<packageName>\\S*)@(?<currentDigest>\\S*)\",\\n"
+      ],
+      "currentValueTemplate": "main",
+      "datasourceTemplate": "git-refs",
+      "packageNameTemplate": "{{{packageName}}}",
+      "depNameTemplate": "{{{depName}}}"
+    },
+    {
+      "fileMatch": [
+        "(M|m)akefile$"
+      ],
+      "matchStrings": [
+        "RHDH_DOCS_VERSION\\s+\\?\\=\\s+\"?(?<currentValue>.*)\"?\\n"
+      ],
+      "datasourceTemplate": "custom.rhdh",
+      "packageNameTemplate": "rhdh",
+      "depNameTemplate": "rhdh"
+    },
+    {
+      "fileMatch": [
+        "Containerfile$"
+      ],
+      "matchStrings": [
+        "ARG\\s+RHDH_DOCS_VERSION\\=\"(?<currentValue>.*)\"\\n"
+      ],
+      "datasourceTemplate": "custom.rhdh",
+      "packageNameTemplate": "rhdh",
+      "depNameTemplate": "rhdh"
+    }
+  ],
+  "customDatasources": {
+    "rhdh": {
+      "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/redhat-developer/rhdh/refs/heads/main/package.json",
+      "format": "json",
+      "transformTemplates": [
+        "{\"releases\":[{\"version\": $replace($.version, \"/(\\\\d+)\\\\.(\\\\d+).(\\\\d+)/\", \"$1.$2\")}]}"
+      ]
+    }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["registry.access.redhat.com/ubi9/ubi-minimal"],
+      "matchUpdateTypes": ["major", "patch"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["quay.io/lightspeed-core/rag-content-cpu"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["quay.io/lightspeed-core/rag-content-gpu"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["python"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchCurrentValue": "\".+@\\s+git\\+.+\",\\n",
+      "enabled": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "groupSlug": "github-actions",
+      "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "dockerfile deps",
+      "groupSlug": "dockerfile-deps",
+      "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "groupName": "python deps",
+      "groupSlug": "python-deps",
+      "commitMessageTopic": "{{depName}}"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "prHourlyLimit": 20,
+  "prConcurrentLimit": 1,
+  "labels": ["renovatebot"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -36,9 +36,9 @@
       "matchStrings": [
         "RHDH_DOCS_VERSION\\s+\\?\\=\\s+\"?(?<currentValue>.*)\"?\\n"
       ],
-      "datasourceTemplate": "custom.rhdh",
-      "packageNameTemplate": "rhdh",
-      "depNameTemplate": "rhdh"
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "redhat-developer/red-hat-developers-documentation-rhdh",
+      "depNameTemplate": "rhdh-docs"
     },
     {
       "fileMatch": [
@@ -47,20 +47,11 @@
       "matchStrings": [
         "ARG\\s+RHDH_DOCS_VERSION\\=\"(?<currentValue>.*)\"\\n"
       ],
-      "datasourceTemplate": "custom.rhdh",
-      "packageNameTemplate": "rhdh",
-      "depNameTemplate": "rhdh"
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "redhat-developer/red-hat-developers-documentation-rhdh",
+      "depNameTemplate": "rhdh-docs"
     }
   ],
-  "customDatasources": {
-    "rhdh": {
-      "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/redhat-developer/rhdh/refs/heads/main/package.json",
-      "format": "json",
-      "transformTemplates": [
-        "{\"releases\":[{\"version\": $.version}]}"
-      ]
-    }
-  },
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],
@@ -94,7 +85,7 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["rhdh"],
+      "matchDepNames": ["rhdh-docs"],
       "extractVersion": "^(?<version>\\d+\\.\\d+)",
       "versioning": "loose"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -116,6 +116,6 @@
     "enabled": true
   },
   "prHourlyLimit": 20,
-  "prConcurrentLimit": 1,
+  "prConcurrentLimit": 10,
   "labels": ["renovatebot"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -57,7 +57,7 @@
       "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/redhat-developer/rhdh/refs/heads/main/package.json",
       "format": "json",
       "transformTemplates": [
-        "{\"releases\":[{\"version\": $replace($.version, \"/(\\\\d+)\\\\.(\\\\d+).(\\\\d+)/\", \"$1.$2\")}]}"
+        "{\"releases\":[{\"version\": $.version}]}"
       ]
     }
   },
@@ -92,6 +92,11 @@
       "matchManagers": ["pep621"],
       "matchCurrentValue": "\".+@\\s+git\\+.+\",\\n",
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["rhdh"],
+      "extractVersion": "^(?<version>\\d+\\.\\d+)",
+      "versioning": "loose"
     },
     {
       "matchManagers": ["github-actions"],

--- a/renovate.json
+++ b/renovate.json
@@ -90,7 +90,7 @@
     },
     {
       "matchManagers": ["pep621"],
-      "matchCurrentValue": "\".+@\\s+git\\+.+\",\\n",
+      "matchPackageNames": ["lightspeed-rag-content"],
       "enabled": false
     },
     {


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/RHIDP-11200

# Renovate Configuration 

Adds initial renovate configuration to start creating Renovate patch PRs on the RHDH RAG content upstream to ensure we maintain a good security score to bring into our product releases and keeps us on top of repeating maintenance.

### How to test changes / Special notes to the reviewer:

Run the following under a local pull of this branch to verify:
```sh
export GITHUB_COM_TOKEN=<github-rate-limit-token> # read-only token works
export LOG_LEVEL=debug

renovate --platform=local
```