### PR TITLE
Make ci-versions.json more clear

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -55,9 +55,9 @@ jobs:
           LLAMA_VERSION="${{ inputs.llama_stack_version }}"
 
           # Validate the version exists in ci-versions.json
-          UPSTREAM_TAG=$(jq -r --arg v "$LLAMA_VERSION" '.images[$v].lightspeed_rag_content_tag // empty' ci-versions.json)
+          UPSTREAM_TAG=$(jq -r --arg v "$LLAMA_VERSION" '.images[] | select(.llama_stack_version == $v) | .lightspeed_rag_content_tag' ci-versions.json)
           if [ -z "$UPSTREAM_TAG" ]; then
-            echo "::error::Llama stack version '$LLAMA_VERSION' not found in ci-versions.json. Available versions: $(jq -r '.images | keys | join(", ")' ci-versions.json)"
+            echo "::error::Llama stack version '$LLAMA_VERSION' not found in ci-versions.json. Available versions: $(jq -r '[.images[].llama_stack_version] | join(", ")' ci-versions.json)"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The [`ci-versions.json`](ci-versions.json) file is the single source of truth fo
             "lightspeed_rag_content_tag": "dev-20260130-1c38b94"
         },
         {
-            "llama_stack_version": "0.4.3",
+            "llama_stack_version": "latest",
             "lightspeed_rag_content_tag": "latest"
         }
     ]

--- a/README.md
+++ b/README.md
@@ -57,30 +57,35 @@ The [`ci-versions.json`](ci-versions.json) file is the single source of truth fo
 
 ```json
 {
-    "images": {
-        "0.3.5": {
+    "images": [
+        {
+            "llama_stack_version": "0.3.5",
             "lightspeed_rag_content_tag": "dev-20260123-60036ff"
         },
-        "0.4.3": {
+        {
+            "llama_stack_version": "0.4.3",
             "lightspeed_rag_content_tag": "dev-20260130-1c38b94"
         },
-        "latest": {
+        {
+            "llama_stack_version": "0.4.3",
             "lightspeed_rag_content_tag": "latest"
         }
-    }
+    ]
 }
 ```
 
-- Each key under `images` is a llama stack version (e.g. `0.3.5`, `0.4.3`, `latest`).
+- `images` is an array of objects, each representing a supported llama stack version.
+- `llama_stack_version` is the llama stack version string (e.g. `0.3.5`, `0.4.3`, `latest`).
 - `lightspeed_rag_content_tag` is the image tag for the upstream `quay.io/lightspeed-core/rag-content-{flavor}` image.
 - The `latest` entry tracks the upstream `latest` tag and is considered experimental / potentially unstable.
 
 ### Adding a New Llama Stack Version
 
-To add support for a new llama stack version, add a new entry under `images` with the version as the key and the pinned upstream image tag:
+To add support for a new llama stack version, append a new object to the `images` array with the version and pinned upstream image tag:
 
 ```json
-"0.5.0": {
+{
+    "llama_stack_version": "0.5.0",
     "lightspeed_rag_content_tag": "dev-20260215-abc1234"
 }
 ```

--- a/ci-versions.json
+++ b/ci-versions.json
@@ -1,13 +1,16 @@
 {
-    "images": {
-        "0.3.5": {
+    "images": [
+        {
+            "llama_stack_version": "0.3.5",
             "lightspeed_rag_content_tag": "dev-20260123-60036ff"
         },
-        "0.4.3": {
+        {
+            "llama_stack_version": "0.4.3",
             "lightspeed_rag_content_tag": "dev-20260211-f43189b"
         },
-        "latest": {
+        {
+            "llama_stack_version": "0.4.3",
             "lightspeed_rag_content_tag": "latest"
         }
-    }
+    ]
 }

--- a/ci-versions.json
+++ b/ci-versions.json
@@ -9,7 +9,7 @@
             "lightspeed_rag_content_tag": "dev-20260211-f43189b"
         },
         {
-            "llama_stack_version": "0.4.3",
+            "llama_stack_version": "latest",
             "lightspeed_rag_content_tag": "latest"
         }
     ]


### PR DESCRIPTION
- Reformats the `ci-versions.json` file to make it more clear what versions of Llama Stack are supported.