### PR TITLE
[RHIDP-12670] Fix gpu build

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -23,7 +23,7 @@ jobs:
   image-test:
     strategy:
       matrix:
-        flavor: [cpu]
+        flavor: [cpu, gpu]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -32,6 +32,16 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 

--- a/Containerfile
+++ b/Containerfile
@@ -22,8 +22,14 @@ ARG NUM_WORKERS=1
 USER 0
 WORKDIR /rag-content
 
-# ADD THIS LINE to pre-download the required NLTK data
 RUN python -c "import nltk; nltk.download('stopwords')"
+
+# The upstream GPU image does not include git; install it if missing.
+RUN if ! command -v git > /dev/null 2>&1; then \
+        (dnf install -y --nodocs --setopt=keepcache=0 git || \
+         microdnf install -y --nodocs --setopt=keepcache=0 git) && \
+        (dnf clean all 2>/dev/null || microdnf clean all 2>/dev/null || true); \
+    fi
 
 COPY scripts/ .
 # Modify script inplace to account for new path

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ This defaults to `cpu` flavor. To build for GPU:
 make build-image FLAVOR=gpu
 ```
 
+#### GPU Build Notes
+
+- No NVIDIA GPU is required to **build** the GPU-flavored image. The CUDA libraries are bundled in the upstream base image. A GPU is only needed to **run** GPU-accelerated workloads from the built image.
+- The `PLATFORM` Makefile variable defaults to `linux/amd64` but can be overridden to match your local architecture (e.g. `PLATFORM=linux/arm64` on Apple Silicon). Both the NVIDIA CUDA base image and the upstream `lightspeed-core/rag-content-gpu` image support `amd64` and `arm64`.
+- Machines without CUDA-capable NVIDIA GPUs can build and test the image, but cannot use it for GPU-accelerated inference.
+
 ## Verifying Vector Database
 
 After building the container image, you can inspect and query the generated vector database to verify its contents.


### PR DESCRIPTION
# Description
- Adds `git` conditionally to the image build if it is not present (not present upstream in gpu base layer, RFE by LCORE was rejected and we have to add it ourself)
- Enables `gpu` build in the test matrix 

# Issue(s)

- https://redhat.atlassian.net/browse/RHIDP-12670
- https://redhat.atlassian.net/browse/RHIDP-12645