### PR TITLE
[RHIDP-11199] remove labels and license inclusion for upstream build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -52,21 +52,4 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:161a4e29ea482bab6048
 COPY --from=lightspeed-core-rag-builder /rag-content/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
 COPY --from=lightspeed-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model
 
-RUN mkdir /licenses
-COPY LICENSE /licenses/
-
-# Labels for enterprise contract
-LABEL com.redhat.component=rhdh-lightspeed-rag-content
-LABEL description="Red Hat Developer Hub Lightspeed RAG content"
-LABEL distribution-scope=private
-LABEL io.k8s.description="Red Hat Developer Hub Lightspeed RAG content"
-LABEL io.k8s.display-name="Red Hat Developer Hub Lightspeed RAG content"
-LABEL io.openshift.tags="developerhub,rhdh,lightspeed,ai,assistant,rag"
-LABEL name=rhdh-lightspeed-rag-content
-LABEL release=1.9
-LABEL url="https://github.com/redhat-ai-dev/rhdh-rag-content"
-LABEL vendor="Red Hat, Inc."
-LABEL version=0.0.1
-LABEL summary="Red Hat Developer Hub Lightspeed RAG content"
-
 USER 65532:65532


### PR DESCRIPTION
ref: https://redhat.atlassian.net/browse/RHIDP-11199

# Description

Previously we needed to comply with Konflux Enterprise Contract testing, recent developments now has the RAG content component included in the RHDH midstream which takes care of all Konflux requirements, these are not needed for upstream builds.

## Removes Productization Labels

Removes productization labels that where used in product builds, handled by midstream.

## Removes license inclusion

Removes inclusion of license under image builds, inclusion in product builds handled by midstream.