### PR TITLE
Add Handling For Pre-Building Vector Store Before Image Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@ src
 tests
 scripts/resolve-base-image.sh
 scripts/open-vector-store-pr.sh
+scripts/extract-vector-db.sh
 
 # Generated files, dont copy from local path during build
 rhdh-product-docs-plaintext

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ OWNERS
 src
 tests
 scripts/resolve-base-image.sh
+scripts/open-vector-store-pr.sh
 
 # Generated files, dont copy from local path during build
 rhdh-product-docs-plaintext

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       base_image: ${{ steps.resolve.outputs.base_image }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -21,14 +21,6 @@ on:
       version:
         description: "The version of RHDH documentation you want to build for. E.g. ('1.8')."
         required: true
-      compute_flavor:
-        description: "The compute flavor for the container build."
-        required: false
-        default: "cpu"
-        type: choice
-        options:
-          - cpu
-          - gpu
       llama_stack_version:
         description: "Llama stack version key from versions.json (e.g. '0.4.3' or 'latest' for experimental)."
         required: true
@@ -54,7 +46,7 @@ jobs:
         run: |
           LLAMA_VERSION="${{ inputs.llama_stack_version }}"
 
-          BASE_IMAGE=$(./scripts/resolve-base-image.sh "$LLAMA_VERSION" "${{ inputs.compute_flavor }}")
+          BASE_IMAGE=$(./scripts/resolve-base-image.sh "$LLAMA_VERSION" "cpu")
 
           # Map 'latest' to 'experimental' for the image tag suffix
           if [ "$LLAMA_VERSION" == "latest" ]; then
@@ -64,10 +56,6 @@ jobs:
           fi
 
           LATEST_TAG="release-${{ inputs.version }}-lls-${TAG_SUFFIX}"
-
-          if [ "${{ inputs.compute_flavor }}" == "gpu" ]; then
-            LATEST_TAG="${LATEST_TAG}-gpu"
-          fi
 
           echo "base_image=${BASE_IMAGE}" >> $GITHUB_OUTPUT
           echo "latest_tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
@@ -113,6 +101,7 @@ jobs:
           build-args: |
             RHDH_DOCS_VERSION=${{ inputs.version }}
             BASE_IMAGE=${{ needs.setup.outputs.base_image }}
+            LLAMA_STACK_VERSION=${{ inputs.llama_stack_version }}
       - name: Check images
         run: |
           buildah images | grep '${{ env.IMAGE_NAME }}'

--- a/.github/workflows/gen-vector-store.yml
+++ b/.github/workflows/gen-vector-store.yml
@@ -82,19 +82,9 @@ jobs:
             BASE_IMAGE=${{ needs.setup.outputs.base_image }}
       - name: Extract vector DB from built image
         run: |
-          buildah unshare -- bash -c '
-            set -euo pipefail
-
-            IMAGE_REF="${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }}"
-            CONTAINER_ID=$(buildah from "$IMAGE_REF")
-            MOUNT_POINT=$(buildah mount "$CONTAINER_ID")
-
-            mkdir -p extracted/vector_db
-            cp -a "$MOUNT_POINT"/rag/vector_db/. extracted/vector_db/
-
-            buildah unmount "$CONTAINER_ID"
-            buildah rm "$CONTAINER_ID"
-          '
+          buildah unshare -- bash ./scripts/extract-vector-db.sh \
+            "${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }}" \
+            "extracted/vector_db"
       - name: Upload extracted vector DB artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:

--- a/.github/workflows/gen-vector-store.yml
+++ b/.github/workflows/gen-vector-store.yml
@@ -1,0 +1,143 @@
+#
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Generate and PR Vector Store
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version of RHDH documentation you want to build for. E.g. ('1.8')."
+        required: true
+      llama_stack_version:
+        description: "Llama stack version key from versions.json (e.g. '0.4.3' or 'latest' for experimental)."
+        required: true
+
+env:
+  TARGET_REPOSITORY: ${{ vars.VECTOR_STORE_TARGET_REPOSITORY || 'redhat-ai-dev/vector-stores' }}
+  TARGET_BASE_BRANCH: ${{ vars.VECTOR_STORE_TARGET_BASE_BRANCH || 'main' }}
+  CONTAINER_FILE: Containerfile.vs
+  LOCAL_IMAGE_NAME: vector-store
+  LOCAL_IMAGE_TAG: latest
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      base_image: ${{ steps.resolve.outputs.base_image }}
+      target_repo: ${{ steps.resolve.outputs.target_repo }}
+      target_branch: ${{ steps.resolve.outputs.target_branch }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Resolve base image and target settings
+        id: resolve
+        run: |
+          LLAMA_VERSION="${{ inputs.llama_stack_version }}"
+          BASE_IMAGE=$(./scripts/resolve-base-image.sh "$LLAMA_VERSION" "cpu")
+
+          echo "base_image=${BASE_IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "target_repo=${{ env.TARGET_REPOSITORY }}" >> "$GITHUB_OUTPUT"
+          echo "target_branch=${{ env.TARGET_BASE_BRANCH }}" >> "$GITHUB_OUTPUT"
+
+          echo "Resolved base image: ${BASE_IMAGE}"
+          echo "Target repository: ${{ env.TARGET_REPOSITORY }}"
+          echo "Target branch: ${{ env.TARGET_BASE_BRANCH }}"
+
+  generate:
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Install buildah and rsync
+        run: |
+          sudo apt update
+          sudo apt install -y buildah rsync
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Build vector-store image with Buildah (amd64 only)
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          layers: true
+          image: ${{ env.LOCAL_IMAGE_NAME }}
+          tags: ${{ env.LOCAL_IMAGE_TAG }}
+          containerfiles: ${{ env.CONTAINER_FILE }}
+          archs: amd64
+          oci: true
+          build-args: |
+            RHDH_DOCS_VERSION=${{ inputs.version }}
+            BASE_IMAGE=${{ needs.setup.outputs.base_image }}
+      - name: Extract vector DB from built image
+        run: |
+          buildah unshare -- bash -c '
+            set -euo pipefail
+
+            IMAGE_REF="${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }}"
+            CONTAINER_ID=$(buildah from "$IMAGE_REF")
+            MOUNT_POINT=$(buildah mount "$CONTAINER_ID")
+
+            mkdir -p extracted/vector_db
+            cp -a "$MOUNT_POINT"/rag/vector_db/. extracted/vector_db/
+
+            buildah unmount "$CONTAINER_ID"
+            buildah rm "$CONTAINER_ID"
+          '
+      - name: Upload extracted vector DB artifact
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        with:
+          name: vector-db
+          path: extracted/vector_db
+          if-no-files-found: error
+
+  open-pr:
+    needs: [setup, generate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Install GitHub CLI
+        run: |
+          sudo apt update
+          sudo apt install -y gh rsync
+      - name: Download vector DB artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: vector-db
+          path: vector-db
+      - name: Checkout source code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: source-repo
+      - name: Checkout target repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: ${{ needs.setup.outputs.target_repo }}
+          ref: ${{ needs.setup.outputs.target_branch }}
+          token: ${{ secrets.TARGET_REPO_TOKEN }}
+          path: target-repo
+          fetch-depth: 0
+      - name: Sync vector DB and open pull request
+        env:
+          GH_TOKEN: ${{ secrets.TARGET_REPO_TOKEN }}
+        run: |
+          ./source-repo/scripts/open-vector-store-pr.sh \
+            "${{ inputs.llama_stack_version }}" \
+            "${{ inputs.version }}" \
+            "${{ needs.setup.outputs.target_repo }}" \
+            "${{ needs.setup.outputs.target_branch }}" \
+            "${{ github.run_id }}" \
+            "${{ github.repository }}" \
+            "vector-db" \
+            "target-repo"

--- a/.github/workflows/gen-vector-store.yml
+++ b/.github/workflows/gen-vector-store.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       base_image: ${{ steps.resolve.outputs.base_image }}
@@ -59,7 +59,7 @@ jobs:
 
   generate:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - name: Install buildah and rsync
@@ -104,7 +104,7 @@ jobs:
 
   open-pr:
     needs: [setup, generate]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Install GitHub CLI

--- a/.github/workflows/gen-vector-store.yml
+++ b/.github/workflows/gen-vector-store.yml
@@ -26,7 +26,7 @@ on:
         required: true
 
 env:
-  TARGET_REPOSITORY: ${{ vars.VECTOR_STORE_TARGET_REPOSITORY || 'redhat-ai-dev/vector-stores' }}
+  TARGET_REPOSITORY: ${{ vars.VECTOR_STORE_TARGET_REPOSITORY || 'redhat-ai-dev/rhdh-vector-stores' }}
   TARGET_BASE_BRANCH: ${{ vars.VECTOR_STORE_TARGET_BASE_BRANCH || 'main' }}
   CONTAINER_FILE: Containerfile.vs
   LOCAL_IMAGE_NAME: vector-store

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -28,7 +28,6 @@ jobs:
     timeout-minutes: 30
     env:
       IMAGE_NAME: rhdh-rag-content-test
-      LLAMA_VERSION: 0.4.3
     permissions:
       contents: read
     steps:
@@ -45,16 +44,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
+      - name: Resolve llama stack version
+        id: llama-version
+        run: |
+          LLAMA_VERSION=$(jq -r '.current_version' versions.json)
+          if [ -z "$LLAMA_VERSION" ] || [ "$LLAMA_VERSION" = "null" ]; then
+            echo "versions.json is missing a valid current_version" >&2
+            exit 1
+          fi
+          echo "version=$LLAMA_VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Resolve base image
         id: resolve
         run: |
-          echo "base_image=$(./scripts/resolve-base-image.sh ${{ env.LLAMA_VERSION }} ${{ matrix.flavor }})" >> $GITHUB_OUTPUT
+          echo "base_image=$(./scripts/resolve-base-image.sh ${{ steps.llama-version.outputs.version }} ${{ matrix.flavor }})" >> $GITHUB_OUTPUT
 
       - name: Build image
         run: |
           docker build \
             --build-arg BASE_IMAGE=${{ steps.resolve.outputs.base_image }} \
-            --build-arg LLAMA_STACK_VERSION=${{ env.LLAMA_VERSION }} \
+            --build-arg LLAMA_STACK_VERSION=${{ steps.llama-version.outputs.version }} \
             -t ${{ env.IMAGE_NAME }}:${{ matrix.flavor }} \
             -f Containerfile .
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -23,11 +23,12 @@ jobs:
   image-test:
     strategy:
       matrix:
-        flavor: [cpu, gpu]
+        flavor: [cpu]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
       IMAGE_NAME: rhdh-rag-content-test
+      LLAMA_VERSION: 0.4.3
     permissions:
       contents: read
     steps:
@@ -47,12 +48,13 @@ jobs:
       - name: Resolve base image
         id: resolve
         run: |
-          echo "base_image=$(./scripts/resolve-base-image.sh latest ${{ matrix.flavor }})" >> $GITHUB_OUTPUT
+          echo "base_image=$(./scripts/resolve-base-image.sh ${{ env.LLAMA_VERSION }} ${{ matrix.flavor }})" >> $GITHUB_OUTPUT
 
       - name: Build image
         run: |
           docker build \
             --build-arg BASE_IMAGE=${{ steps.resolve.outputs.base_image }} \
+            --build-arg LLAMA_STACK_VERSION=${{ env.LLAMA_VERSION }} \
             -t ${{ env.IMAGE_NAME }}:${{ matrix.flavor }} \
             -f Containerfile .
 

--- a/Containerfile
+++ b/Containerfile
@@ -23,23 +23,12 @@ ARG VECTOR_STORE_REF="main"
 USER 0
 WORKDIR /rag-content
 
-
-RUN set -euo pipefail && \
-    git clone --depth=1 --branch "${VECTOR_STORE_REF}" "${VECTOR_STORE_REPOSITORY}" vector-stores && \
-    VECTOR_STORE_DIR="vector-stores/${LLAMA_STACK_VERSION}/vector_db" && \
-    DOCS_VECTOR_STORE_DIR="${VECTOR_STORE_DIR}/rhdh_product_docs/${RHDH_DOCS_VERSION}" && \
-    if [ ! -d "${VECTOR_STORE_DIR}" ]; then \
-      echo "Missing vector store directory for LLS version '${LLAMA_STACK_VERSION}' at '${VECTOR_STORE_DIR}'" >&2; \
-      exit 1; \
-    fi && \
-    if [ ! -d "${DOCS_VECTOR_STORE_DIR}" ]; then \
-      echo "Missing vector store docs directory for RHDH version '${RHDH_DOCS_VERSION}' at '${DOCS_VECTOR_STORE_DIR}'" >&2; \
-      exit 1; \
-    fi && \
-    mkdir -p /prepared/rag/vector_db /prepared/rag && \
-    mkdir -p /prepared/rag/vector_db/rhdh_product_docs && \
-    cp -a "${DOCS_VECTOR_STORE_DIR}" "/prepared/rag/vector_db/rhdh_product_docs/${RHDH_DOCS_VERSION}" && \
-    cp -a /rag-content/embeddings_model /prepared/rag/embeddings_model
+COPY scripts/prepare-vector-store.sh scripts/prepare-vector-store.sh
+RUN ./scripts/prepare-vector-store.sh \
+    "${VECTOR_STORE_REPOSITORY}" \
+    "${VECTOR_STORE_REF}" \
+    "${LLAMA_STACK_VERSION}" \
+    "${RHDH_DOCS_VERSION}"
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
 COPY --from=lightspeed-core-rag-builder /prepared/rag/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs

--- a/Containerfile
+++ b/Containerfile
@@ -16,40 +16,33 @@
 ARG BASE_IMAGE=quay.io/lightspeed-core/rag-content-cpu@sha256:297db4e12b07dcf460b1b5186764f32b6bb41841d77d085aa5e650e30f7b9031
 FROM ${BASE_IMAGE} AS lightspeed-core-rag-builder
 ARG RHDH_DOCS_VERSION="1.9"
-ARG NUM_WORKERS=1
+ARG LLAMA_STACK_VERSION="0.4.3"
+ARG VECTOR_STORE_REPOSITORY="https://github.com/redhat-ai-dev/rhdh-vector-stores.git"
+ARG VECTOR_STORE_REF="main"
 
 USER 0
 WORKDIR /rag-content
 
-RUN python -c "import nltk; nltk.download('stopwords')"
 
-# The upstream GPU image does not include git; install it if missing.
-RUN if ! command -v git > /dev/null 2>&1; then \
-        (dnf install -y --nodocs --setopt=keepcache=0 git || \
-         microdnf install -y --nodocs --setopt=keepcache=0 git) && \
-        (dnf clean all 2>/dev/null || microdnf clean all 2>/dev/null || true); \
-    fi
-
-COPY scripts/ .
-# Modify script inplace to account for new path
-RUN sed -i 's/scripts\///' get_rhdh_plaintext_docs.sh
-RUN ./get_rhdh_plaintext_docs.sh $RHDH_DOCS_VERSION
-
-RUN set -e && for RHDH_VERSION in $(ls -1 rhdh-product-docs-plaintext); do \
-        python ./generate_embeddings_rhdh.py \
-            -f rhdh-product-docs-plaintext/${RHDH_VERSION} \
-            -md embeddings_model \
-            -mn ${EMBEDDING_MODEL} \
-            -o vector_db/rhdh_product_docs/${RHDH_VERSION} \
-            -w ${NUM_WORKERS} \
-            -i rhdh-product-docs-$(echo $RHDH_VERSION | sed 's/\./_/g') \
-            -t rhdh-docs-topic-map/rhdh_topic_map.yaml \
-            --vector-store-type=llamastack-faiss \
-            -v ${RHDH_VERSION}; \
-    done
+RUN set -euo pipefail && \
+    git clone --depth=1 --branch "${VECTOR_STORE_REF}" "${VECTOR_STORE_REPOSITORY}" vector-stores && \
+    VECTOR_STORE_DIR="vector-stores/${LLAMA_STACK_VERSION}/vector_db" && \
+    DOCS_VECTOR_STORE_DIR="${VECTOR_STORE_DIR}/rhdh_product_docs/${RHDH_DOCS_VERSION}" && \
+    if [ ! -d "${VECTOR_STORE_DIR}" ]; then \
+      echo "Missing vector store directory for LLS version '${LLAMA_STACK_VERSION}' at '${VECTOR_STORE_DIR}'" >&2; \
+      exit 1; \
+    fi && \
+    if [ ! -d "${DOCS_VECTOR_STORE_DIR}" ]; then \
+      echo "Missing vector store docs directory for RHDH version '${RHDH_DOCS_VERSION}' at '${DOCS_VECTOR_STORE_DIR}'" >&2; \
+      exit 1; \
+    fi && \
+    mkdir -p /prepared/rag/vector_db /prepared/rag && \
+    mkdir -p /prepared/rag/vector_db/rhdh_product_docs && \
+    cp -a "${DOCS_VECTOR_STORE_DIR}" "/prepared/rag/vector_db/rhdh_product_docs/${RHDH_DOCS_VERSION}" && \
+    cp -a /rag-content/embeddings_model /prepared/rag/embeddings_model
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
-COPY --from=lightspeed-core-rag-builder /rag-content/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
-COPY --from=lightspeed-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model
+COPY --from=lightspeed-core-rag-builder /prepared/rag/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
+COPY --from=lightspeed-core-rag-builder /prepared/rag/embeddings_model /rag/embeddings_model
 
 USER 65532:65532

--- a/Containerfile.local
+++ b/Containerfile.local
@@ -1,0 +1,48 @@
+#
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG BASE_IMAGE=quay.io/lightspeed-core/rag-content-cpu@sha256:297db4e12b07dcf460b1b5186764f32b6bb41841d77d085aa5e650e30f7b9031
+FROM ${BASE_IMAGE} AS lightspeed-core-rag-builder
+ARG RHDH_DOCS_VERSION="1.9"
+ARG NUM_WORKERS=1
+
+USER 0
+WORKDIR /rag-content
+
+RUN python -c "import nltk; nltk.download('stopwords')"
+
+COPY scripts/ .
+# Modify script inplace to account for new path
+RUN sed -i 's/scripts\///' get_rhdh_plaintext_docs.sh
+RUN ./get_rhdh_plaintext_docs.sh $RHDH_DOCS_VERSION
+
+RUN set -e && for RHDH_VERSION in $(ls -1 rhdh-product-docs-plaintext); do \
+        python ./generate_embeddings_rhdh.py \
+            -f rhdh-product-docs-plaintext/${RHDH_VERSION} \
+            -md embeddings_model \
+            -mn ${EMBEDDING_MODEL} \
+            -o vector_db/rhdh_product_docs/${RHDH_VERSION} \
+            -w ${NUM_WORKERS} \
+            -i rhdh-product-docs-$(echo $RHDH_VERSION | sed 's/\./_/g') \
+            -t rhdh-docs-topic-map/rhdh_topic_map.yaml \
+            --vector-store-type=llamastack-faiss \
+            -v ${RHDH_VERSION}; \
+    done
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
+COPY --from=lightspeed-core-rag-builder /rag-content/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
+COPY --from=lightspeed-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model
+
+USER 65532:65532

--- a/Containerfile.vs
+++ b/Containerfile.vs
@@ -1,0 +1,47 @@
+#
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG BASE_IMAGE=quay.io/lightspeed-core/rag-content-cpu@sha256:297db4e12b07dcf460b1b5186764f32b6bb41841d77d085aa5e650e30f7b9031
+FROM ${BASE_IMAGE} AS lightspeed-core-rag-builder
+ARG RHDH_DOCS_VERSION="1.9"
+ARG NUM_WORKERS=1
+
+USER 0
+WORKDIR /rag-content
+
+RUN python -c "import nltk; nltk.download('stopwords')"
+
+COPY scripts/ .
+# Modify script inplace to account for new path
+RUN sed -i 's/scripts\///' get_rhdh_plaintext_docs.sh
+RUN ./get_rhdh_plaintext_docs.sh $RHDH_DOCS_VERSION
+
+RUN set -e && for RHDH_VERSION in $(ls -1 rhdh-product-docs-plaintext); do \
+        python ./generate_embeddings_rhdh.py \
+            -f rhdh-product-docs-plaintext/${RHDH_VERSION} \
+            -md embeddings_model \
+            -mn ${EMBEDDING_MODEL} \
+            -o vector_db/rhdh_product_docs/${RHDH_VERSION} \
+            -w ${NUM_WORKERS} \
+            -i rhdh-product-docs-$(echo $RHDH_VERSION | sed 's/\./_/g') \
+            -t rhdh-docs-topic-map/rhdh_topic_map.yaml \
+            --vector-store-type=llamastack-faiss \
+            -v ${RHDH_VERSION}; \
+    done
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
+COPY --from=lightspeed-core-rag-builder /rag-content/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
+
+USER 65532:65532

--- a/Containerfile.vs
+++ b/Containerfile.vs
@@ -41,7 +41,8 @@ RUN set -e && for RHDH_VERSION in $(ls -1 rhdh-product-docs-plaintext); do \
             -v ${RHDH_VERSION}; \
     done
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
-COPY --from=lightspeed-core-rag-builder /rag-content/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
+# Keep generated content under /rag while preserving /rag-content as the working directory. needed to preserve other pieces that depend on where it was built and finally stored
+RUN mkdir -p /rag/vector_db && \
+    mv /rag-content/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
 
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ IMAGE_NAME ?= rhdh-rag-content
 BASE_IMAGE := $(shell ./scripts/resolve-base-image.sh "$(LLAMA_STACK_VERSION)" "$(FLAVOR)")
 
 build-image: ## Build the container image
-	podman build --platform ${PLATFORM} -t ${IMAGE_NAME} -f Containerfile --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg RHDH_DOCS_VERSION=$(RHDH_DOCS_VERSION) .
+	podman build --platform ${PLATFORM} -t ${IMAGE_NAME} -f Containerfile.local \
+		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		--build-arg RHDH_DOCS_VERSION=$(RHDH_DOCS_VERSION) .
 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The [`versions.json`](versions.json) file is the single source of truth for mapp
 
 ```json
 {
+    "current_version": "0.4.3",
     "base_image": "quay.io/lightspeed-core/rag-content",
     "images": [
         {
@@ -112,6 +113,7 @@ The [`versions.json`](versions.json) file is the single source of truth for mapp
 }
 ```
 
+- `current_version` is the default llama stack version used by PR smoke tests (`.github/workflows/pr-tests.yml`).
 - `base_image` is the upstream image repository prefix (e.g. `quay.io/lightspeed-core/rag-content`).
 - `images` is an array of objects, each representing a supported llama stack version.
 - `llama_stack_version` is the version string (e.g. `0.3.5`, `0.4.3`, `latest`).

--- a/README.md
+++ b/README.md
@@ -8,27 +8,62 @@
 
 ## Overview
 
-This repository produces Red Hat Developer Hub (RHDH) Lightspeed RAG content container images. Images are built on top of the upstream [`lightspeed-core/rag-content`](https://github.com/lightspeed-core/rag-content) base images, with the specific upstream image tag determined by the selected llama stack version via [`ci-versions.json`](ci-versions.json).
+This repository produces Red Hat Developer Hub (RHDH) Lightspeed RAG content container images. Images are built on top of the upstream [`lightspeed-core/rag-content`](https://github.com/lightspeed-core/rag-content) base images, with the specific upstream image tag determined by the selected llama stack version via [`versions.json`](versions.json).
 
 The container images are published to [redhat-ai-dev/rag-content](https://quay.io/repository/redhat-ai-dev/rag-content?tab=tags) on Quay.io.
 
-## CI / Building Images
+Pre-generated vector stores are stored in a separate repository: [`redhat-ai-dev/rhdh-vector-stores`](https://github.com/redhat-ai-dev/rhdh-vector-stores).
 
-Container images are built and pushed through a GitHub Actions workflow triggered manually from the **Actions** tab (`workflow_dispatch`).
+## CI Workflows
 
-### Workflow Inputs
+There are two GitHub Actions workflows, both triggered manually via `workflow_dispatch`.
+
+### 1. Generate and PR Vector Store (`gen-vector-store.yml`)
+
+Generates a vector store from RHDH documentation and opens a pull request to the [vector-stores repository](https://github.com/redhat-ai-dev/rhdh-vector-stores) with the result.
+
+#### Inputs
 
 | Input | Type | Required | Description |
 |-------|------|----------|-------------|
-| `version` | string | yes | RHDH documentation version, e.g. `1.8` |
-| `compute_flavor` | choice (`cpu` / `gpu`) | no (default: `cpu`) | Compute flavor for the container build |
-| `llama_stack_version` | string | yes | A llama stack version key from `ci-versions.json`, e.g. `0.4.3` or `latest` for experimental |
+| `version` | string | yes | RHDH documentation version, e.g. `1.9` |
+| `llama_stack_version` | string | yes | Llama stack version key from `versions.json`, e.g. `0.4.3` or `latest` |
 
-### How It Works
+#### How It Works
 
-1. The workflow reads `ci-versions.json` and looks up the `lightspeed_rag_content_tag` for the given `llama_stack_version`.
-2. That tag is passed as the `TAG` build arg to the Containerfile, which pulls the corresponding upstream `quay.io/lightspeed-core/rag-content-{flavor}:{tag}` base image.
-3. If `latest` is selected as the llama stack version, the resulting image is tagged with `experimental` to signal that it tracks an upstream moving target and may be unstable.
+1. Resolves the upstream base image from `versions.json` for the given `llama_stack_version`.
+2. Builds `Containerfile.vs` which generates embeddings and the vector database inside the container.
+3. Extracts the `/rag/vector_db` directory from the built image.
+4. Clones the vector-stores repository, places the extracted content under `<llama_stack_version>/vector_db/`, and opens a PR.
+
+The resulting PR places files in the vector-stores repo at:
+
+```
+<llama_stack_version>/vector_db/rhdh_product_docs/<RHDH_DOCS_VERSION>/
+```
+
+### 2. Build and Push RAG Container (`build-and-push.yml`)
+
+Builds the final multi-arch container image and pushes it to Quay.io.
+
+> [!IMPORTANT]
+> The vector store for the target `llama_stack_version` and `version` must already exist in the [vector-stores repository](https://github.com/redhat-ai-dev/rhdh-vector-stores). If it does not, run the **Generate and PR Vector Store** workflow first and merge the resulting PR before building.
+
+#### Inputs
+
+| Input | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | string | yes | RHDH documentation version, e.g. `1.9` |
+| `llama_stack_version` | string | yes | Llama stack version key from `versions.json`, e.g. `0.4.3` or `latest` |
+
+#### How It Works
+
+1. Resolves the upstream CPU base image from `versions.json` for the given `llama_stack_version`.
+2. Builds `Containerfile` which clones the vector-stores repo at `main` (or a configurable ref for release builds), validates that the expected vector store directory exists, and copies the vector DB and embeddings model into a minimal UBI image.
+3. Pushes architecture-specific images (amd64 + arm64) to Quay.io.
+4. Creates and pushes multi-arch manifests.
+
+The build will **fail** if the vector store for the requested `llama_stack_version` and `version` is not present in the vector-stores repo.
 
 ### Image Tags
 
@@ -40,64 +75,74 @@ release-<doc_version>-lls-<llama_stack_version | experimental>
 
 Examples:
 
-- `release-1.8-lls-0.4.3` — stable build pinned to llama stack 0.4.3
-- `release-1.8-lls-0.3.5` — stable build pinned to llama stack 0.3.5
-- `release-1.8-lls-experimental` — built from upstream `latest`, may be unstable
+- `release-1.9-lls-0.4.3` — stable build pinned to llama stack 0.4.3
+- `release-1.9-lls-0.3.5` — stable build pinned to llama stack 0.3.5
+- `release-1.9-lls-experimental` — built from upstream `latest`, may be unstable
 
 A SHA-preserved tag is also pushed for every build for historic image preservation:
 
-- `release-1.8-lls-0.4.3-<github_sha>`
-- `release-1.8-lls-experimental-<github_sha>`
+- `release-1.9-lls-0.4.3-<github_sha>`
+- `release-1.9-lls-experimental-<github_sha>`
 
-## ci-versions.json
+## versions.json
 
-The [`ci-versions.json`](ci-versions.json) file is the single source of truth for mapping llama stack versions to upstream base image tags.
+The [`versions.json`](versions.json) file is the single source of truth for mapping llama stack versions to upstream base image digests.
 
 ### Structure
 
 ```json
 {
+    "base_image": "quay.io/lightspeed-core/rag-content",
     "images": [
         {
-            "llama_stack_version": "0.3.5",
-            "lightspeed_rag_content_tag": "dev-20260123-60036ff"
-        },
-        {
             "llama_stack_version": "0.4.3",
-            "lightspeed_rag_content_tag": "dev-20260130-1c38b94"
+            "digests": {
+                "cpu": "sha256:314a616c0efc944e376f35a50c9d98f6aab53e68a0971a2195024474aee8209c",
+                "gpu": "sha256:47885985ee3f534c1cec33b4e9c5d43b870ec791b963354cb3e9c48b36ead902"
+            }
         },
         {
             "llama_stack_version": "latest",
-            "lightspeed_rag_content_tag": "latest"
+            "digests": {
+                "cpu": "sha256:...",
+                "gpu": "sha256:..."
+            }
         }
     ]
 }
 ```
 
+- `base_image` is the upstream image repository prefix (e.g. `quay.io/lightspeed-core/rag-content`).
 - `images` is an array of objects, each representing a supported llama stack version.
-- `llama_stack_version` is the llama stack version string (e.g. `0.3.5`, `0.4.3`, `latest`).
-- `lightspeed_rag_content_tag` is the image tag for the upstream `quay.io/lightspeed-core/rag-content-{flavor}` image.
+- `llama_stack_version` is the version string (e.g. `0.3.5`, `0.4.3`, `latest`).
+- `digests` contains pinned image digests keyed by compute flavor (`cpu` / `gpu`). CI workflows always use `cpu`.
 - The `latest` entry tracks the upstream `latest` tag and is considered experimental / potentially unstable.
 
 ### Adding a New Llama Stack Version
 
-To add support for a new llama stack version, append a new object to the `images` array with the version and pinned upstream image tag:
+To add support for a new llama stack version:
+
+1. Append a new object to the `images` array in `versions.json` with the version and pinned digests:
 
 ```json
 {
     "llama_stack_version": "0.5.0",
-    "lightspeed_rag_content_tag": "dev-20260215-abc1234"
+    "digests": {
+        "cpu": "sha256:abc123...",
+        "gpu": "sha256:def456..."
+    }
 }
 ```
 
-Then trigger the workflow with `llama_stack_version` set to `0.5.0`.
+2. Run the **Generate and PR Vector Store** workflow with the new `llama_stack_version` and desired `version`. Merge the resulting PR in the vector-stores repo.
+3. Run the **Build and Push RAG Container** workflow with `llama_stack_version` set to `0.5.0`.
 
 ## Release Strategy
 
-- **Future release branches** (cut from `main` after this CI change) carry their own copy of `ci-versions.json` pinned to the llama stack versions validated for that release.
-- **Existing release branches** (pre-refactor) retain the old workflow with the `experimental` boolean and are unaffected.
-- **Cutting a new release**: branch from `main`, review `ci-versions.json`, and lock it to only the versions that are known-good for that release (i.e., remove `latest` if desired).
-- **Rebuilding a historic image**: navigate to the release branch in GitHub and trigger the workflow. The workflow reads the branch's own `ci-versions.json`, ensuring the correct upstream image tags are used.
+- **Future release branches** (cut from `main`) carry their own copy of `versions.json` pinned to the llama stack versions validated for that release.
+- **Existing release branches** (pre-refactor) retain the old workflow and are unaffected.
+- **Cutting a new release**: branch from `main`, review `versions.json`, and lock it to only the versions that are known-good for that release (i.e., remove `latest` if desired). For the `Containerfile`, update `VECTOR_STORE_REF` to point to the appropriate release branch or tag in the vector-stores repo.
+- **Rebuilding a historic image**: navigate to the release branch in GitHub and trigger the workflow. The workflow reads the branch's own `versions.json`, ensuring the correct upstream image digests are used.
 
 ## Local Development
 
@@ -134,17 +179,7 @@ To build a container image locally using the Makefile:
 make build-image
 ```
 
-This defaults to `cpu` flavor. To build for GPU:
-
-```bash
-make build-image FLAVOR=gpu
-```
-
-#### GPU Build Notes
-
-- No NVIDIA GPU is required to **build** the GPU-flavored image. The CUDA libraries are bundled in the upstream base image. A GPU is only needed to **run** GPU-accelerated workloads from the built image.
-- The `PLATFORM` Makefile variable defaults to `linux/amd64` but can be overridden to match your local architecture (e.g. `PLATFORM=linux/arm64` on Apple Silicon). Both the NVIDIA CUDA base image and the upstream `lightspeed-core/rag-content-gpu` image support `amd64` and `arm64`.
-- Machines without CUDA-capable NVIDIA GPUs can build and test the image, but cannot use it for GPU-accelerated inference.
+This uses `Containerfile.local` which generates the vector DB during image build — no vector-stores repo dependency required. The `PLATFORM` variable defaults to `linux/amd64` but can be overridden (e.g. `PLATFORM=linux/arm64` on Apple Silicon).
 
 ## Verifying Vector Database
 
@@ -152,14 +187,13 @@ After building the container image, you can inspect and query the generated vect
 
 ### Building the Builder Stage
 
-The final container image is minimal and only contains the vector database files. To run verification scripts, build the builder stage which includes Python and all dependencies:
+The `Containerfile.local` builder stage includes Python and all dependencies. To build just that stage for interactive verification:
 
 ```bash
-podman build --platform linux/arm64 \
+podman build --platform linux/amd64 \
     --target lightspeed-core-rag-builder \
     -t rhdh-rag-builder \
-    -f Containerfile \
-    --build-arg FLAVOR=cpu .
+    -f Containerfile.local .
 ```
 
 Then start an interactive shell:

--- a/scripts/extract-vector-db.sh
+++ b/scripts/extract-vector-db.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <image_ref> <output_dir>" >&2
+    echo "  image_ref   Local image reference (e.g. vector-store:latest)" >&2
+    echo "  output_dir  Destination directory for extracted vector DB" >&2
+    exit 1
+fi
+
+IMAGE_REF="$1"
+OUTPUT_DIR="$2"
+
+CONTAINER_ID=""
+MOUNT_POINT=""
+
+cleanup() {
+    if [ -n "$CONTAINER_ID" ]; then
+        if [ -n "$MOUNT_POINT" ]; then
+            buildah unmount "$CONTAINER_ID" >/dev/null 2>&1 || true
+        fi
+        buildah rm "$CONTAINER_ID" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+CONTAINER_ID=$(buildah from "$IMAGE_REF")
+MOUNT_POINT=$(buildah mount "$CONTAINER_ID")
+
+mkdir -p "$OUTPUT_DIR"
+cp -a "$MOUNT_POINT"/rag/vector_db/. "$OUTPUT_DIR"/

--- a/scripts/open-vector-store-pr.sh
+++ b/scripts/open-vector-store-pr.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Syncs a vector DB artifact into a target repository and opens a pull request.
+# Requires: git, gh (GitHub CLI), rsync
+# Expects GH_TOKEN to be set in the environment for gh authentication.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <llama_stack_version> <rhdh_version> <target_repo> <target_branch> <run_id> <source_repository> <vector_db_source> <target_repo_path>" >&2
+    echo "" >&2
+    echo "  llama_stack_version  Llama Stack version (e.g. '0.4.3')" >&2
+    echo "  rhdh_version         RHDH documentation version (e.g. '1.8')" >&2
+    echo "  target_repo          Target GitHub repository (e.g. 'org/repo')" >&2
+    echo "  target_branch        Base branch for the PR (e.g. 'main')" >&2
+    echo "  run_id               Unique run identifier for the branch name" >&2
+    echo "  source_repository    Source repository for the PR body link (e.g. 'org/source-repo')" >&2
+    echo "  vector_db_source     Path to the downloaded vector DB artifact directory" >&2
+    echo "  target_repo_path     Path to the checked-out target repository" >&2
+    exit 1
+}
+
+if [ $# -ne 8 ]; then
+    usage
+fi
+
+LLAMA_STACK_VERSION="$1"
+RHDH_VERSION="$2"
+TARGET_REPO="$3"
+TARGET_BRANCH="$4"
+RUN_ID="$5"
+SOURCE_REPOSITORY="$6"
+VECTOR_DB_SOURCE="$7"
+TARGET_REPO_PATH="$8"
+
+VERSIONED_DESTINATION="${LLAMA_STACK_VERSION}/vector_db"
+BRANCH_NAME="bot/vector-db-${RHDH_VERSION}-lls-${LLAMA_STACK_VERSION}-${RUN_ID}"
+PR_TITLE="Update vector_db for RHDH ${RHDH_VERSION} (LLS ${LLAMA_STACK_VERSION})"
+
+mkdir -p "${TARGET_REPO_PATH}/${VERSIONED_DESTINATION}"
+rsync -a --delete "${VECTOR_DB_SOURCE}/" "${TARGET_REPO_PATH}/${VERSIONED_DESTINATION}/"
+
+cd "${TARGET_REPO_PATH}"
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git checkout -b "${BRANCH_NAME}"
+git add "${VERSIONED_DESTINATION}"
+
+git commit -m "${PR_TITLE}"
+git push --set-upstream origin "${BRANCH_NAME}"
+
+PR_URL=$(gh pr create \
+    --repo "${TARGET_REPO}" \
+    --base "${TARGET_BRANCH}" \
+    --head "${BRANCH_NAME}" \
+    --title "${PR_TITLE}" \
+    --body "Automated vector DB update from https://github.com/${SOURCE_REPOSITORY}/actions/runs/${RUN_ID}")
+
+echo "Created PR: ${PR_URL}"

--- a/scripts/prepare-vector-store.sh
+++ b/scripts/prepare-vector-store.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <vector_store_repository> <vector_store_ref> <llama_stack_version> <rhdh_docs_version>" >&2
+    echo "" >&2
+    echo "  vector_store_repository  Vector store repository URL (e.g. 'https://github.com/org/repo.git')" >&2
+    echo "  vector_store_ref         Repository branch or ref to clone (e.g. 'main')" >&2
+    echo "  llama_stack_version      Llama Stack version directory (e.g. '0.4.3')" >&2
+    echo "  rhdh_docs_version        RHDH documentation version directory (e.g. '1.9')" >&2
+    exit 1
+}
+
+if [ $# -ne 4 ]; then
+    usage
+fi
+
+VECTOR_STORE_REPOSITORY="$1"
+VECTOR_STORE_REF="$2"
+LLAMA_STACK_VERSION="$3"
+RHDH_DOCS_VERSION="$4"
+
+git clone --depth=1 --branch "${VECTOR_STORE_REF}" "${VECTOR_STORE_REPOSITORY}" vector-stores
+
+VECTOR_STORE_DIR="vector-stores/${LLAMA_STACK_VERSION}/vector_db"
+DOCS_VECTOR_STORE_DIR="${VECTOR_STORE_DIR}/rhdh_product_docs/${RHDH_DOCS_VERSION}"
+
+if [ ! -d "${VECTOR_STORE_DIR}" ]; then
+    echo "Missing vector store directory for LLS version '${LLAMA_STACK_VERSION}' at '${VECTOR_STORE_DIR}'" >&2
+    exit 1
+fi
+
+if [ ! -d "${DOCS_VECTOR_STORE_DIR}" ]; then
+    echo "Missing vector store docs directory for RHDH version '${RHDH_DOCS_VERSION}' at '${DOCS_VECTOR_STORE_DIR}'" >&2
+    exit 1
+fi
+
+mkdir -p /prepared/rag/vector_db/rhdh_product_docs
+cp -a "${DOCS_VECTOR_STORE_DIR}" "/prepared/rag/vector_db/rhdh_product_docs/${RHDH_DOCS_VERSION}"
+cp -a /rag-content/embeddings_model /prepared/rag/embeddings_model

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,5 @@
 {
+    "current_version": "0.4.3",
     "base_image": "quay.io/lightspeed-core/rag-content",
     "images": [
         {


### PR DESCRIPTION
- Adds new workflow for building the vector store _once_ and opening PR to store in https://github.com/redhat-ai-dev/rhdh-vector-stores
- RAG image build now references the vector stores located at the above repo, configurable by branch and llama stack version
- Removes `gpu` selector for builds, since we package the embedding_model and vector_store into a minimal image, we don't even use CUDA or anything anyways, it does nothing
   - Updates tests as a result
- Keeps `Containerfile.local` the same where it rebuilds vector store each time, as for local building/test it doesn't matter
- Updates readme as there was some stale elements


**Note:** I have configured a fine-grained PAT to facilitate the PR permissions for the bot on the workflow. I have also opened https://redhat.atlassian.net/browse/RHIDP-12993 to move to using a GH app instead of a PAT, but that can be done later.