### PR TITLE
[RHIDP-12994] chore: remove gpu references for base layer image

### DIFF
--- a/.github/workflows/gen-vector-store.yml
+++ b/.github/workflows/gen-vector-store.yml
@@ -49,7 +49,7 @@ jobs:
         id: resolve
         run: |
           LLAMA_VERSION="${{ inputs.llama_stack_version }}"
-          BASE_IMAGE=$(./scripts/resolve-base-image.sh "$LLAMA_VERSION" "cpu")
+          BASE_IMAGE=$(./scripts/resolve-base-image.sh "$LLAMA_VERSION")
 
           if [ "$LLAMA_VERSION" == "latest" ]; then
             TAG_SUFFIX="experimental"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -21,13 +21,11 @@ on:
 
 jobs:
   image-test:
-    strategy:
-      matrix:
-        flavor: [cpu]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
       IMAGE_NAME: rhdh-rag-content-test
+      IMAGE_TAG: smoke
     permissions:
       contents: read
     steps:
@@ -73,9 +71,9 @@ jobs:
         run: |
           docker build \
             --build-arg RAG_ASSETS_URL=${{ steps.release-asset.outputs.asset_url }} \
-            -t ${{ env.IMAGE_NAME }}:${{ matrix.flavor }} \
+            -t ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
             -f Containerfile .
 
       - name: Validate image content
         run: |
-          .ci/test_image_content.sh "${{ env.IMAGE_NAME }}:${{ matrix.flavor }}"
+          .ci/test_image_content.sh "${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FLAVOR ?= cpu
 LLAMA_STACK_VERSION ?= latest
 RHDH_DOCS_VERSION ?= 1.9
 NUM_WORKERS ?= $$(( $(shell nproc --all) / 2))
 PLATFORM ?= linux/amd64
 IMAGE_NAME ?= rhdh-rag-content
 
-BASE_IMAGE := $(shell ./scripts/resolve-base-image.sh "$(LLAMA_STACK_VERSION)" "$(FLAVOR)")
+BASE_IMAGE := $(shell ./scripts/resolve-base-image.sh "$(LLAMA_STACK_VERSION)")
 
 build-image: ## Build the container image
 	podman build --platform ${PLATFORM} -t ${IMAGE_NAME} -f Containerfile.local \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This repository produces Red Hat Developer Hub (RHDH) Lightspeed RAG content container images. Images are built on top of the upstream [`lightspeed-core/rag-content`](https://github.com/lightspeed-core/rag-content) base images, with the specific upstream image tag determined by the selected llama stack version via [`versions.json`](versions.json).
+This repository produces Red Hat Developer Hub (RHDH) Lightspeed RAG content container images. Images are built on top of the upstream [`lightspeed-core/rag-content`](https://github.com/lightspeed-core/rag-content) CPU base images, with the specific upstream image digest determined by the selected llama stack version via [`versions.json`](versions.json).
 
 The container images are published to [redhat-ai-dev/rag-content](https://quay.io/repository/redhat-ai-dev/rag-content?tab=tags) on Quay.io.
 
@@ -93,47 +93,38 @@ The [`versions.json`](versions.json) file is the single source of truth for mapp
 
 ```json
 {
-    "current_version": "0.4.3",
-    "base_image": "quay.io/lightspeed-core/rag-content",
+    "current_version": "0.5.0",
+    "base_image": "quay.io/lightspeed-core/rag-content-cpu",
     "images": [
         {
             "llama_stack_version": "0.4.3",
-            "digests": {
-                "cpu": "sha256:314a616c0efc944e376f35a50c9d98f6aab53e68a0971a2195024474aee8209c",
-                "gpu": "sha256:47885985ee3f534c1cec33b4e9c5d43b870ec791b963354cb3e9c48b36ead902"
-            }
+            "digest": "sha256:314a616c0efc944e376f35a50c9d98f6aab53e68a0971a2195024474aee8209c"
         },
         {
             "llama_stack_version": "latest",
-            "digests": {
-                "cpu": "sha256:...",
-                "gpu": "sha256:..."
-            }
+            "digest": "sha256:..."
         }
     ]
 }
 ```
 
 - `current_version` is the default llama stack version used by PR smoke tests (`.github/workflows/pr-tests.yml`).
-- `base_image` is the upstream image repository prefix (e.g. `quay.io/lightspeed-core/rag-content`).
+- `base_image` is the upstream CPU image repository (e.g. `quay.io/lightspeed-core/rag-content-cpu`).
 - `images` is an array of objects, each representing a supported llama stack version.
 - `llama_stack_version` is the version string (e.g. `0.3.5`, `0.4.3`, `latest`).
-- `digests` contains pinned image digests keyed by compute flavor (`cpu` / `gpu`). CI workflows always use `cpu`.
+- `digest` is the pinned upstream image digest for that llama stack version.
 - The `latest` entry tracks the upstream `latest` tag and is considered experimental / potentially unstable.
 
 ### Adding a New Llama Stack Version
 
 To add support for a new llama stack version:
 
-1. Append a new object to the `images` array in `versions.json` with the version and pinned digests:
+1. Append a new object to the `images` array in `versions.json` with the version and pinned digest:
 
 ```json
 {
     "llama_stack_version": "0.5.0",
-    "digests": {
-        "cpu": "sha256:abc123...",
-        "gpu": "sha256:def456..."
-    }
+    "digest": "sha256:abc123..."
 }
 ```
 

--- a/renovate.json
+++ b/renovate.json
@@ -69,11 +69,6 @@
       "enabled": false
     },
     {
-      "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["quay.io/lightspeed-core/rag-content-gpu"],
-      "enabled": false
-    },
-    {
       "matchManagers": ["pep621"],
       "matchPackageNames": ["python"],
       "matchUpdateTypes": ["major", "minor"],

--- a/scripts/resolve-base-image.sh
+++ b/scripts/resolve-base-image.sh
@@ -19,28 +19,26 @@ set -euo pipefail
 VERSIONS_FILE="$(cd "$(dirname "$0")/.." && pwd)/versions.json"
 
 usage() {
-    echo "Usage: $0 <llama_stack_version> <flavor>" >&2
+    echo "Usage: $0 <llama_stack_version>" >&2
     echo "  llama_stack_version  Version key from versions.json (e.g. '0.4.3', 'latest')" >&2
-    echo "  flavor               Compute flavor ('cpu' or 'gpu')" >&2
     exit 1
 }
 
-if [ $# -ne 2 ]; then
+if [ $# -ne 1 ]; then
     usage
 fi
 
 VERSION="$1"
-FLAVOR="$2"
 
 BASE_REPO=$(jq -r '.base_image' "$VERSIONS_FILE")
-DIGEST=$(jq -r --arg version "$VERSION" --arg flavor "$FLAVOR" \
-    '.images[] | select(.llama_stack_version == $version) | .digests[$flavor]' "$VERSIONS_FILE")
+DIGEST=$(jq -r --arg version "$VERSION" \
+    '.images[] | select(.llama_stack_version == $version) | .digest' "$VERSIONS_FILE")
 
 if [ -z "$DIGEST" ] || [ "$DIGEST" == "null" ]; then
     AVAILABLE=$(jq -r '[.images[].llama_stack_version] | join(", ")' "$VERSIONS_FILE")
-    echo "Error: Could not resolve digest for version='$VERSION' flavor='$FLAVOR' in $VERSIONS_FILE" >&2
+    echo "Error: Could not resolve digest for version='$VERSION' in $VERSIONS_FILE" >&2
     echo "Available versions: $AVAILABLE" >&2
     exit 1
 fi
 
-echo "${BASE_REPO}-${FLAVOR}@${DIGEST}"
+echo "${BASE_REPO}@${DIGEST}"

--- a/versions.json
+++ b/versions.json
@@ -1,34 +1,22 @@
 {
     "current_version": "0.5.0",
-    "base_image": "quay.io/lightspeed-core/rag-content",
+    "base_image": "quay.io/lightspeed-core/rag-content-cpu",
     "images": [
         {
             "llama_stack_version": "0.3.5",
-            "digests": {
-                "cpu": "sha256:81467bbb8a3390be6113c0e9998f5b1c154fa859f7883a3387ded896ef9a4d1a",
-                "gpu": "sha256:200e8e224de0ed4fc87d1960ca16a776c7e44981b12ec687bf908e884c0f390f"
-            }
+            "digest": "sha256:81467bbb8a3390be6113c0e9998f5b1c154fa859f7883a3387ded896ef9a4d1a"
         },
         {
             "llama_stack_version": "0.4.3",
-            "digests": {
-                "cpu": "sha256:314a616c0efc944e376f35a50c9d98f6aab53e68a0971a2195024474aee8209c",
-                "gpu": "sha256:47885985ee3f534c1cec33b4e9c5d43b870ec791b963354cb3e9c48b36ead902"
-            }
+            "digest": "sha256:314a616c0efc944e376f35a50c9d98f6aab53e68a0971a2195024474aee8209c"
         },
         {
             "llama_stack_version": "0.5.0",
-            "digests": {
-                "cpu": "sha256:8816c11286ce4a260e5b7fbf9ee8b305459aab4458cef0ff7983dd6cb4502de7",
-                "gpu": "sha256:8da6d9e937a84495f9102af051aaf6ec013529b41f154bf5e0f063d12e3604a2"
-            }
+            "digest": "sha256:8816c11286ce4a260e5b7fbf9ee8b305459aab4458cef0ff7983dd6cb4502de7"
         },
         {
             "llama_stack_version": "latest",
-            "digests": {
-                "cpu": "sha256:84b59df985a29bf33e9a2d5d75253118803f53d81638de0d7f2dd342e3f4ce97",
-                "gpu": "sha256:79d7824d8a2d44b2d75bcff0a57e8e216f4c4057b20c4b43abf64d13d188a84b"
-            }
+            "digest": "sha256:84b59df985a29bf33e9a2d5d75253118803f53d81638de0d7f2dd342e3f4ce97"
         }
     ]
 }


### PR DESCRIPTION
# Description
- Removes `gpu` references as we don't care about `cpu` vs. `gpu` for building the vector store and storing as an artifact

# Issue

https://redhat.atlassian.net/browse/RHIDP-12994