### PR TITLE
Pin rpm packages for UBI9 builds

### DIFF
--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,0 +1,23 @@
+# RHDH RAG content RPM dependencies
+# after editing, run (https://github.com/konflux-ci/rpm-lockfile-prototype):
+#   rpm-lockfile-prototype -f Containerfile rpms.in.yaml
+# to regenerate rpms.lock.yaml
+#
+# Note that the repoid values are special, and must be from here:
+# https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/known_rpm_repositories.yml
+
+allowerasing: true
+contentOrigin:
+  repos:
+    - repoid: ubi-9-for-$basearch-appstream-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/os/
+    - repoid: ubi-9-for-$basearch-appstream-source-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/source/SRPMS
+    - repoid: ubi-9-for-$basearch-baseos-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os/
+    - repoid: ubi-9-for-$basearch-baseos-source-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/source/SRPMS
+
+packages:
+  - gzip
+  - tar

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -1,0 +1,34 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 171206
+    checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
+    name: gzip
+    evr: 1.12-1.el9
+    sourcerpm: gzip-1.12-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-9.el9_7.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 906521
+    checksum: sha256:4c0beb933074a5254c297e8968b3f41ec5a02b23056997ddcf526fe7e6166482
+    name: tar
+    evr: 2:1.34-9.el9_7
+    sourcerpm: tar-1.34-9.el9_7.src.rpm
+  source:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
+    size: 856147
+    checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
+    name: gzip
+    evr: 1.12-1.el9
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
+    size: 2282680
+    checksum: sha256:9b84935c6072500fa28674521fe13816a8be44c50bb8eaf5ec73994782161250
+    name: tar
+    evr: 2:1.34-9.el9_7
+  module_metadata: []


### PR DESCRIPTION
## Description

Pins the rpm packages for UBI9 builds that is needed for Red Hat Konflux.

Adds `gzip` and `tar` dependencies and pins their digests in the lockfile.

## Reviewer Notes

You can try re-running the lockfile generation using [rpm-lockfile-prototype CLI](https://github.com/konflux-ci/rpm-lockfile-prototype#installation):

```
rpm-lockfile-prototype -f Containerfile rpms.in.yaml
```