### PR TITLE
Change base images to ubi-micro

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -29,7 +29,7 @@ RUN test -n "${RAG_ASSETS_URL}" && \
     test -d extracted/vector_db/rhdh_product_docs && \
     test -d extracted/embeddings_model
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.7@sha256:2173487b3b72b1a7b11edc908e9bbf1726f9df46a4f78fd6d19a2bab0a701f38
 
 COPY --from=rag-assets-downloader /tmp/rag-assets/extracted/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
 COPY --from=rag-assets-downloader /tmp/rag-assets/extracted/embeddings_model /rag/embeddings_model

--- a/Containerfile.local
+++ b/Containerfile.local
@@ -41,7 +41,7 @@ RUN set -e && for RHDH_VERSION in $(ls -1 rhdh-product-docs-plaintext); do \
             -v ${RHDH_VERSION}; \
     done
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.7@sha256:2173487b3b72b1a7b11edc908e9bbf1726f9df46a4f78fd6d19a2bab0a701f38
 COPY --from=lightspeed-core-rag-builder /rag-content/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
 COPY --from=lightspeed-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model
 

--- a/renovate.json
+++ b/renovate.json
@@ -59,7 +59,6 @@
     },
     {
       "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["registry.access.redhat.com/ubi9/ubi-minimal"],
       "matchUpdateTypes": ["major", "patch"],
       "enabled": false
     },


### PR DESCRIPTION
# Description

Changes final stage base images of RHDH RAG content to use the UBI 9 Micro image as steps don't use anything from minimal at this stage.