### PR TITLE
Add Release Notes Handling

### DIFF
--- a/.github/workflows/gen-vector-store.yml
+++ b/.github/workflows/gen-vector-store.yml
@@ -81,6 +81,15 @@ jobs:
           sudo apt install -y buildah
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Create GitHub App token for release-notes-mirror
+        id: release-notes-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ secrets.RELEASE_NOTES_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_NOTES_APP_PRIVATE_KEY }}
+          owner: redhat-ai-dev
+          repositories: release-notes-mirror
+          permission-contents: read
       - name: Build vector-store image with Buildah (amd64 only)
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
@@ -93,6 +102,7 @@ jobs:
           build-args: |
             RHDH_DOCS_VERSION=${{ inputs.version }}
             BASE_IMAGE=${{ needs.setup.outputs.base_image }}
+            GITHUB_PAT=${{ steps.release-notes-app-token.outputs.token }}
       - name: Extract RAG assets from built image
         run: |
           buildah unshare -- bash ./scripts/extract-vector-db.sh \

--- a/Containerfile.local
+++ b/Containerfile.local
@@ -15,7 +15,8 @@
 # limitations under the License.
 ARG BASE_IMAGE=quay.io/lightspeed-core/rag-content-cpu@sha256:297db4e12b07dcf460b1b5186764f32b6bb41841d77d085aa5e650e30f7b9031
 FROM ${BASE_IMAGE} AS lightspeed-core-rag-builder
-ARG RHDH_DOCS_VERSION="1.9"
+ARG RHDH_DOCS_VERSION="1.10"
+ARG GITHUB_PAT=""
 ARG NUM_WORKERS=1
 
 USER 0
@@ -26,7 +27,7 @@ RUN python -c "import nltk; nltk.download('stopwords')"
 COPY scripts/ .
 # Modify script inplace to account for new path
 RUN sed -i 's/scripts\///' get_rhdh_plaintext_docs.sh
-RUN ./get_rhdh_plaintext_docs.sh $RHDH_DOCS_VERSION
+RUN GITHUB_PAT=${GITHUB_PAT} ./get_rhdh_plaintext_docs.sh $RHDH_DOCS_VERSION
 
 RUN set -e && for RHDH_VERSION in $(ls -1 rhdh-product-docs-plaintext); do \
         python ./generate_embeddings_rhdh.py \

--- a/Containerfile.vs
+++ b/Containerfile.vs
@@ -16,6 +16,7 @@
 ARG BASE_IMAGE=quay.io/lightspeed-core/rag-content-cpu@sha256:297db4e12b07dcf460b1b5186764f32b6bb41841d77d085aa5e650e30f7b9031
 FROM ${BASE_IMAGE} AS lightspeed-core-rag-builder
 ARG RHDH_DOCS_VERSION="1.9"
+ARG GITHUB_PAT=""
 ARG NUM_WORKERS=1
 
 USER 0
@@ -26,7 +27,7 @@ RUN python -c "import nltk; nltk.download('stopwords')"
 COPY scripts/ .
 # Modify script inplace to account for new path
 RUN sed -i 's/scripts\///' get_rhdh_plaintext_docs.sh
-RUN ./get_rhdh_plaintext_docs.sh $RHDH_DOCS_VERSION
+RUN GITHUB_PAT=${GITHUB_PAT} ./get_rhdh_plaintext_docs.sh $RHDH_DOCS_VERSION
 
 RUN set -e && for RHDH_VERSION in $(ls -1 rhdh-product-docs-plaintext); do \
         python ./generate_embeddings_rhdh.py \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 LLAMA_STACK_VERSION ?= latest
-RHDH_DOCS_VERSION ?= 1.9
+RHDH_DOCS_VERSION ?= 1.10
+GITHUB_PAT ?= 
 NUM_WORKERS ?= $$(( $(shell nproc --all) / 2))
 PLATFORM ?= linux/amd64
 IMAGE_NAME ?= rhdh-rag-content
@@ -25,7 +26,8 @@ BASE_IMAGE := $(shell ./scripts/resolve-base-image.sh "$(LLAMA_STACK_VERSION)")
 build-image: ## Build the container image
 	podman build --platform ${PLATFORM} -t ${IMAGE_NAME} -f Containerfile.local \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
-		--build-arg RHDH_DOCS_VERSION=$(RHDH_DOCS_VERSION) .
+		--build-arg RHDH_DOCS_VERSION=$(RHDH_DOCS_VERSION) \
+		--build-arg GITHUB_PAT=$(GITHUB_PAT) .
 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ The container images are published to [redhat-ai-dev/rag-content](https://quay.i
 
 Pre-generated RAG assets (vector store + embeddings model) are published as GitHub Release artifacts in this repository.
 
+## Mirroring Release Notes
+
+The RHDH release notes live in an internal GitLab repository. Before running the RAG asset generation workflow, you must ensure the [release-notes-mirror](https://github.com/redhat-ai-dev/release-notes-mirror) GitHub repository is up to date:
+
+```bash
+./scripts/mirror-release-notes.sh
+```
+
+> [!NOTE]
+> You must be connected to the VPN to run this script. It clones from GitLab and pushes a mirror to GitHub.
+
+Run this whenever the internal release notes have changed and you need to regenerate RAG assets.
+
 ## CI Workflows
 
 There are two GitHub Actions workflows.

--- a/README.md
+++ b/README.md
@@ -170,8 +170,10 @@ The `pyproject.toml` and `uv.lock` files are maintained for local development us
 To build a container image locally using the Makefile:
 
 ```bash
-make build-image
+make build-image GITHUB_PAT=<your-pat>
 ```
+
+The `GITHUB_PAT` is required to clone the private [release-notes-mirror](https://github.com/redhat-ai-dev/release-notes-mirror) repository during the build. The PAT needs read access to that repository — a fine-grained token with **Contents: Read** permission scoped to `redhat-ai-dev/release-notes-mirror`, or a classic token with `repo` scope.
 
 This uses `Containerfile.local` which generates the vector DB during image build — no vector-stores repo dependency required. The `PLATFORM` variable defaults to `linux/amd64` but can be overridden (e.g. `PLATFORM=linux/arm64` on Apple Silicon).
 

--- a/scripts/get_rhdh_plaintext_docs.sh
+++ b/scripts/get_rhdh_plaintext_docs.sh
@@ -20,14 +20,30 @@ set -eou pipefail
 
 RHDH_VERSION=$1
 
-trap "rm -rf red-hat-developers-documentation-rhdh" EXIT
+GITHUB_PAT="${GITHUB_PAT:-}"
+
+trap "rm -rf red-hat-developers-documentation-rhdh release-notes-mirror" EXIT
 
 rm -rf rhdh-product-docs-plaintext/${RHDH_VERSION}
 rm -rf rhdh-docs-topic-map
+rm -rf release-notes-mirror
 
 git clone --single-branch --branch release-${RHDH_VERSION} https://github.com/redhat-developer/red-hat-developers-documentation-rhdh
 
 git clone --single-branch --branch release-${RHDH_VERSION} https://github.com/redhat-ai-dev/rhdh-docs-topic-map
+
+RELEASE_NOTES_REPO="https://github.com/redhat-ai-dev/release-notes-mirror.git"
+if [ -n "$GITHUB_PAT" ]; then
+    RELEASE_NOTES_REPO="https://${GITHUB_PAT}@github.com/redhat-ai-dev/release-notes-mirror.git"
+fi
+git clone --single-branch --branch release-${RHDH_VERSION} "$RELEASE_NOTES_REPO"
+
+RELEASE_NOTES_DEST="red-hat-developers-documentation-rhdh/titles/release-notes"
+mkdir -p "${RELEASE_NOTES_DEST}/modules/generated"
+cp release-notes-mirror/master.adoc "${RELEASE_NOTES_DEST}/"
+cp -r release-notes-mirror/modules/generated/. "${RELEASE_NOTES_DEST}/modules/generated/"
+cp release-notes-mirror/modules/ref-release-notes-fixed-security-issues.adoc \
+    "${RELEASE_NOTES_DEST}/modules/"
 
 python scripts/convert_adoc_to_txt_rhdh.py \
     -i red-hat-developers-documentation-rhdh \

--- a/scripts/mirror-release-notes.sh
+++ b/scripts/mirror-release-notes.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: You must be logged into the VPN to use this script.
+
+set -euo pipefail
+
+GITLAB_REPO="https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-developer-hub-release-notes.git"
+GITHUB_REPO="https://github.com/redhat-ai-dev/release-notes-mirror.git"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Cloning from GitLab (requires VPN)..."
+git clone --mirror "$GITLAB_REPO" "$TMPDIR/mirror.git"
+
+echo "Pushing to GitHub..."
+cd "$TMPDIR/mirror.git"
+git push --mirror "$GITHUB_REPO"
+
+echo "Mirror complete."


### PR DESCRIPTION
## Description
- Adds handling for the release notes mirror script.
- Updates the workflow to use a configured GH app to get a short lived token to get read access to the private mirror repo for building

## Issue

https://redhat.atlassian.net/browse/RHIDP-12641