### PR TITLE
chore(docker deps): RHEL 9.8 updates

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# https://registry.access.redhat.com/ubi9/ubi-minimal
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc AS rag-assets-downloader
 
 ARG RAG_ASSETS_URL
@@ -29,6 +30,7 @@ RUN test -n "${RAG_ASSETS_URL}" && \
     test -d extracted/vector_db/rhdh_product_docs && \
     test -d extracted/embeddings_model
 
+# https://registry.access.redhat.com/ubi9/ubi-micro
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.8-1779858820@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 
 COPY --from=rag-assets-downloader /tmp/rag-assets/extracted/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs

--- a/Containerfile.local
+++ b/Containerfile.local
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# https://quay.io/lightspeed-core/rag-content-cpu
 ARG BASE_IMAGE=quay.io/lightspeed-core/rag-content-cpu@sha256:297db4e12b07dcf460b1b5186764f32b6bb41841d77d085aa5e650e30f7b9031
 FROM ${BASE_IMAGE} AS lightspeed-core-rag-builder
 ARG RHDH_DOCS_VERSION="1.10"
@@ -42,6 +44,7 @@ RUN set -e && for RHDH_VERSION in $(ls -1 rhdh-product-docs-plaintext); do \
             -v ${RHDH_VERSION}; \
     done
 
+# https://registry.access.redhat.com/ubi9/ubi-micro
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.8-1779858820@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 COPY --from=lightspeed-core-rag-builder /rag-content/vector_db/rhdh_product_docs /rag/vector_db/rhdh_product_docs
 COPY --from=lightspeed-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model

--- a/Containerfile.vs
+++ b/Containerfile.vs
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# https://quay.io/lightspeed-core/rag-content-cpu
 ARG BASE_IMAGE=quay.io/lightspeed-core/rag-content-cpu@sha256:297db4e12b07dcf460b1b5186764f32b6bb41841d77d085aa5e650e30f7b9031
 FROM ${BASE_IMAGE} AS lightspeed-core-rag-builder
 ARG RHDH_DOCS_VERSION="1.9"

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -11,13 +11,13 @@ arches:
     name: gzip
     evr: 1.12-1.el9
     sourcerpm: gzip-1.12-1.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-9.el9_7.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/t/tar-1.34-11.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 906521
-    checksum: sha256:4c0beb933074a5254c297e8968b3f41ec5a02b23056997ddcf526fe7e6166482
+    size: 913256
+    checksum: sha256:58b622ab7bc225731a2473e677f16c9eb51b1ed218a86a7aa039a6fed665f245
     name: tar
-    evr: 2:1.34-9.el9_7
-    sourcerpm: tar-1.34-9.el9_7.src.rpm
+    evr: 2:1.34-11.el9
+    sourcerpm: tar-1.34-11.el9.src.rpm
   source:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
     repoid: ubi-9-for-x86_64-baseos-source-rpms
@@ -25,10 +25,10 @@ arches:
     checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
     name: gzip
     evr: 1.12-1.el9
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-11.el9.src.rpm
     repoid: ubi-9-for-x86_64-baseos-source-rpms
-    size: 2282680
-    checksum: sha256:9b84935c6072500fa28674521fe13816a8be44c50bb8eaf5ec73994782161250
+    size: 2294162
+    checksum: sha256:13204f7499944b3fe773cbdf0b9bb2de31eaa9a4c69f31830fb9e54506bcb9b6
     name: tar
-    evr: 2:1.34-9.el9_7
+    evr: 2:1.34-11.el9
   module_metadata: []


### PR DESCRIPTION
## Description

Continuing from dependabot PR #29 and addressing review comments for 1.10 backport PR #33, this PR includes the following:
- Base image URL comments
- Generation of the `rpms.lock.yaml` for RPM pinning compatibility with RHEL 9.8
